### PR TITLE
Actually fix crits

### DIFF
--- a/src/main/java/dev/shadowsoffire/attributeslib/api/ALCombatRules.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/api/ALCombatRules.java
@@ -76,7 +76,7 @@ public class ALCombatRules {
      * @return The modified damage value, after applying armor, accounting for the attacker's bypass.
      */
     public static float getDamageAfterArmor(LivingEntity target, DamageSource src, float amount, float armor, float toughness) {
-        AttributesLib.LOGGER.info("getDamageAfterArmor was passed " + amount);
+        //AttributesLib.LOGGER.info("getDamageAfterArmor was passed " + amount);
 
         if (src.getEntity() instanceof LivingEntity attacker) {
             float shred = (float) attacker.getAttributeValue(Attributes.ARMOR_SHRED);

--- a/src/main/java/dev/shadowsoffire/attributeslib/api/ALCombatRules.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/api/ALCombatRules.java
@@ -1,6 +1,7 @@
 package dev.shadowsoffire.attributeslib.api;
 
 import dev.shadowsoffire.attributeslib.ALConfig;
+import dev.shadowsoffire.attributeslib.AttributesLib;
 import dev.shadowsoffire.attributeslib.api.ALObjects.Attributes;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
@@ -75,6 +76,8 @@ public class ALCombatRules {
      * @return The modified damage value, after applying armor, accounting for the attacker's bypass.
      */
     public static float getDamageAfterArmor(LivingEntity target, DamageSource src, float amount, float armor, float toughness) {
+        AttributesLib.LOGGER.info("getDamageAfterArmor was passed " + amount);
+
         if (src.getEntity() instanceof LivingEntity attacker) {
             float shred = (float) attacker.getAttributeValue(Attributes.ARMOR_SHRED);
             float bypassResist = Math.min(toughness * 0.02F, 0.6F);
@@ -123,6 +126,7 @@ public class ALCombatRules {
      * @see #getDamageAfterArmor(LivingEntity, DamageSource, float, float, float)
      */
     public static float getArmorDamageReduction(float damage, float armor) {
+//        AttributesLib.LOGGER.info("getArmorDamageReduction was passed " + damage);
         float a = getAValue(damage);
         if (ALConfig.getArmorExpr().isPresent()) {
             return ALConfig.getArmorExpr().get().setVariable("a", new BigDecimal(a)).setVariable("damage", new BigDecimal(damage)).setVariable("armor", new BigDecimal(armor)).eval().floatValue();

--- a/src/main/java/dev/shadowsoffire/attributeslib/api/IFormattableAttribute.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/api/IFormattableAttribute.java
@@ -67,6 +67,9 @@ public interface IFormattableAttribute {
      */
     default MutableComponent toComponent(AttributeModifier modif, TooltipFlag flag) {
         Attribute attr = this.ths();
+        if(attr == null){
+            return null;
+        }
         double value = modif.getAmount();
 
         MutableComponent comp;
@@ -193,7 +196,13 @@ public interface IFormattableAttribute {
      * Helper method to invoke {@link #toComponent(AttributeModifier, TooltipFlag)}.
      */
     public static MutableComponent toComponent(Attribute attr, AttributeModifier modif, TooltipFlag flag) {
-        return ((IFormattableAttribute) attr).toComponent(modif, flag);
+        if(attr != null){
+            return ((IFormattableAttribute) attr).toComponent(modif, flag);
+        }
+        else{
+            return null;
+        }
+
     }
 
     /**

--- a/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesGui.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/client/AttributesGui.java
@@ -254,8 +254,11 @@ public class AttributesGui implements Renderable, GuiEventListener, NarratableEn
                     for (AttributeModifier modif : modifiers) {
                         if (modif.getAmount() != 0) {
                             Component comp = fAttr.toComponent(modif, AttributesLib.getTooltipFlag());
-                            var src = modifiersToSources.get(modif.getId());
-                            finalTooltip.add(new AttributeModifierComponent(src, comp, this.font, this.leftPos - 16));
+                            if(comp != null){
+                                var src = modifiersToSources.get(modif.getId());
+                                finalTooltip.add(new AttributeModifierComponent(src, comp, this.font, this.leftPos - 16));
+                            }
+
                         }
                     }
                     color = ChatFormatting.GRAY;

--- a/src/main/java/dev/shadowsoffire/attributeslib/impl/AttributeEvents.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/impl/AttributeEvents.java
@@ -201,7 +201,7 @@ public class AttributeEvents {
 
     public static void apothCriticalStrike() {
         LivingEntityEvents.HURT.register((source, damaged, amount) -> {
-            LivingEntity attacker = source.getEntity() instanceof LivingEntity le ? le : null;
+            LivingEntity attacker = source.getEntity() instanceof LivingEntity le && !le.level().isClientSide ? le : null;
             if (attacker == null) return amount;
 
             double critChance = attacker.getAttributeValue(ALObjects.Attributes.CRIT_CHANCE);
@@ -212,10 +212,12 @@ public class AttributeEvents {
 
             // Roll for crits. Each overcrit reduces the effectiveness by 15%
             // We stop rolling when crit chance fails or the crit damage would reduce the total damage dealt.
-            while (rand.nextFloat() <= critChance && critDmg > 0.0F) {
+            //AttributesLib.LOGGER.info("Outer: critChance " + critChance + " critMult " + critMult + " critDmg " + critDmg);
+            while (rand.nextFloat() <= critChance && critDmg > 1.0F) {
                 critChance--;
                 critMult *= critDmg;
                 critDmg *= 0.85F;
+                //AttributesLib.LOGGER.info("Loop: critChance " + critChance + " critMult " + critMult + " critDmg " + critDmg);
             }
 
             amount *= critMult;

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/CombatRulesMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/CombatRulesMixin.java
@@ -26,7 +26,10 @@ public class CombatRulesMixin {
      */
     @Inject(method ="getDamageAfterAbsorb", at = @At("HEAD"), cancellable = true)
     private static void zenith_attributes$getDamageAfterAbsorb(float damage, float totalArmor, float toughnessAttribute, CallbackInfoReturnable<Float> cir) {
-        AttributesLib.LOGGER.trace("Invocation of CombatRules#getDamageAfterAbsorb is bypassing armor pen.");
-        cir.setReturnValue(damage * ALCombatRules.getArmorDamageReduction(damage, totalArmor));
+//        AttributesLib.LOGGER.info("Invocation of CombatRules#getDamageAfterAbsorb is bypassing armor pen."); //incorrect?
+//        AttributesLib.LOGGER.info("getDamageAfterAbsorb was passed " + damage);
+        float ret = damage; //* ALCombatRules.getArmorDamageReduction(damage, totalArmor);
+//        AttributesLib.LOGGER.info("getDamageAfterAbsorb returned " + ret);
+        cir.setReturnValue(ret);
     }
 }

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
@@ -2,6 +2,7 @@ package dev.shadowsoffire.attributeslib.mixin;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import de.dafuqs.additionalentityattributes.AdditionalEntityAttributes;
+import dev.shadowsoffire.attributeslib.AttributesLib;
 import dev.shadowsoffire.attributeslib.api.ALCombatRules;
 import dev.shadowsoffire.attributeslib.api.ALObjects;
 import dev.shadowsoffire.attributeslib.api.HealEvent;
@@ -81,6 +82,7 @@ public abstract class LivingEntityMixin extends Entity {
 
     @ModifyExpressionValue(at = @At(value = "INVOKE", target = "Lnet/minecraft/world/damagesource/CombatRules;getDamageAfterAbsorb(FFF)F"), method = "getDamageAfterArmorAbsorb", require = 1)
     public float zenith_applyArmorPen(float amount, DamageSource src) {
+//        AttributesLib.LOGGER.info("LivingEntityMixin#zenith_applyArmorPen was passed " + amount);
         return ALCombatRules.getDamageAfterArmor((LivingEntity) (Object) this, src, amount,((LivingEntity)(Object) this).getArmorValue(), (float) ((LivingEntity)(Object) this).getAttributeValue(Attributes.ARMOR_TOUGHNESS));
     }
 


### PR DESCRIPTION
I'd like to apologize for the confusion regarding these. In 0.2.4 crits are still reducing damage. My initial solution should have been the ``float critDmg = 1 + (float) attacker.getAttributeValue(AdditionalEntityAttributes.CRITICAL_BONUS_DAMAGE);``

Additionally, crits are now only calculated on server. This didn't make a practical difference in my testing, but I did noticed ``rand.nextFloat() `` could return different values. The calculation on the client seemed to just be ignored.