### PR TITLE
Remove Projectile Damage Attribute and add ARROW_DAMAGE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,6 @@ dependencies {
 	// Reach entity attributes
 	modApi(include("com.jamieswhiteshirt:reach-entity-attributes:${project.reach_lib_version}"))
 
-	// Projectile Damage Attribute
-	modApi(include("maven.modrinth:projectile-damage-attribute:${project.projectile_damage}-fabric"))
-
 	// Additional Entity Attributes
 	modApi(include("maven.modrinth:AdditionalEntityAttributes:${project.additional_attributes}"))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ fabric_version=0.92.1+1.20.1
 reach_lib_version=2.4.0
 port_lib_version=2.3.4+1.20.1
 cardinal_components_version=5.2.2
-projectile_damage=3.2.2+1.20.1
 additional_attributes=1.7.3+1.20.0
 fakerlib_version= 0.1.3
 pal_version=1.8.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.20.1
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.2.4
+mod_version=0.2.5
 maven_group=dev.bagel
 archives_base_name=zenith_attributes
 

--- a/src/main/java/dev/shadowsoffire/attributeslib/api/ALObjects.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/api/ALObjects.java
@@ -33,8 +33,7 @@ public class ALObjects {
         /**
          * Arrow Damage. Base value = (1.0) = 100% default arrow damage
          */
-        // Use EntityAttributes_ProjectileDamage.GENERIC_PROJECTILE_DAMAGE instead projectile_damage:generic
-        //public static final Attribute ARROW_DAMAGE = new RangedAttribute("zenith_attributes:arrow_damage", 1.0D, 0.0D, 10.0D).setSyncable(true);
+        public static final Attribute ARROW_DAMAGE = new RangedAttribute("zenith_attributes:arrow_damage", 1.0D, 0.0D, 10.0D).setSyncable(true);
 
         /**
          * Arrow Velocity. Base value = (1.0) = 100% default arrow velocity
@@ -150,7 +149,7 @@ public class ALObjects {
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("overheal"), OVERHEAL);
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("ghost_health"), GHOST_HEALTH);
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("mining_speed"), MINING_SPEED);
-            //Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("arrow_damage"), ARROW_DAMAGE);
+            Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("arrow_damage"), ARROW_DAMAGE);
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("arrow_velocity"), ARROW_VELOCITY);
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("healing_received"), HEALING_RECEIVED);
             Registry.register(BuiltInRegistries.ATTRIBUTE, AttributesLib.loc("armor_pierce"), ARMOR_PIERCE);

--- a/src/main/java/dev/shadowsoffire/attributeslib/components/ZenithAttributesComponents.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/components/ZenithAttributesComponents.java
@@ -8,9 +8,12 @@ import dev.shadowsoffire.attributeslib.AttributesLib;
 import net.minecraft.world.entity.projectile.AbstractArrow;
 
 public class ZenithAttributesComponents implements EntityComponentInitializer {
-    public static final ComponentKey<BooleanComponent> ARROW_DONE = ComponentRegistry.getOrCreate(AttributesLib.loc("arrow_done"), BooleanComponent.class);
+    public static final ComponentKey<BooleanComponent> ARROW_VELOCITY_DONE = ComponentRegistry.getOrCreate(AttributesLib.loc("arrow_velocity_done"), BooleanComponent.class);
+    public static final ComponentKey<BooleanComponent> ARROW_DAMAGE_DONE = ComponentRegistry.getOrCreate(AttributesLib.loc("arrow_damage_done"), BooleanComponent.class);
+
     @Override
     public void registerEntityComponentFactories(EntityComponentFactoryRegistry registry) {
-        registry.registerFor(AbstractArrow.class, ARROW_DONE, arrow -> new BooleanComponent(AttributesLib.loc("arrow_done").toString()));
+        registry.registerFor(AbstractArrow.class, ARROW_VELOCITY_DONE, arrow -> new BooleanComponent(AttributesLib.loc("arrow_velocity_done").toString()));
+        registry.registerFor(AbstractArrow.class, ARROW_DAMAGE_DONE, arrow -> new BooleanComponent(AttributesLib.loc("arrow_damage_done").toString()));
     }
 }

--- a/src/main/java/dev/shadowsoffire/attributeslib/impl/AttributeEvents.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/impl/AttributeEvents.java
@@ -255,17 +255,35 @@ public class AttributeEvents {
     }
 
     /**
-     * Handles arrow velocity
-     * Injected via @See ProjectileMixin
+     * Handles {@link ALObjects.Attributes#ARROW_DAMAGE}
+     * See AbstractArrowMixin
+     */
+    public static double modifyArrowDamage(AbstractArrow arrow, LivingEntity shooter, double baseDamage) {
+        if (ZenithAttributesComponents.ARROW_DAMAGE_DONE.get(arrow).getValue()) return baseDamage;
+
+        double arrowDamage = shooter.getAttributeValue(ALObjects.Attributes.ARROW_DAMAGE);
+        if (!Double.isNaN(arrowDamage)) {
+            baseDamage *= arrowDamage;
+        }
+
+        ZenithAttributesComponents.ARROW_DAMAGE_DONE.get(arrow).setValue(true);
+        return baseDamage;
+    }
+
+    /**
+     * Handles {@link ALObjects.Attributes#ARROW_VELOCITY}
+     * See ProjectileMixin
      */
     public static void modifyArrowVelocity(Args args, AbstractArrow arrow, float velocity) {
         if (arrow.level().isClientSide) return;
-        if (ZenithAttributesComponents.ARROW_DONE.get(arrow).getValue()) return;
+        if (ZenithAttributesComponents.ARROW_VELOCITY_DONE.get(arrow).getValue()) return;
         if (arrow.getOwner() instanceof LivingEntity le) {
-            if (Double.isNaN(le.getAttributeValue(ALObjects.Attributes.ARROW_VELOCITY))) return;
-            args.set(3, (float) (velocity * le.getAttributeValue(ALObjects.Attributes.ARROW_VELOCITY)));
+            double arrowVelocity = le.getAttributeValue(ALObjects.Attributes.ARROW_VELOCITY);
+            if (!Double.isNaN(arrowVelocity)) {
+                args.set(3, (float) (velocity * arrowVelocity));
+            }
         }
-        ZenithAttributesComponents.ARROW_DONE.get(arrow).setValue(true);
+        ZenithAttributesComponents.ARROW_VELOCITY_DONE.get(arrow).setValue(true);
     }
 
     /**

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/AbstractArrowMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/AbstractArrowMixin.java
@@ -1,0 +1,21 @@
+package dev.shadowsoffire.attributeslib.mixin;
+
+import dev.shadowsoffire.attributeslib.impl.AttributeEvents;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.projectile.AbstractArrow;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(AbstractArrow.class)
+public abstract class AbstractArrowMixin {
+
+    @ModifyVariable(method = "setBaseDamage", at = @At("HEAD"), argsOnly = true)
+    private double zenith_attributes$modifyArrowDamage(double baseDamage) {
+        AbstractArrow arrow = (AbstractArrow) (Object) this;
+        if (arrow.getOwner() instanceof LivingEntity shooter) {
+            return AttributeEvents.modifyArrowDamage(arrow, shooter, baseDamage);
+        }
+        return baseDamage;
+    }
+}

--- a/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
+++ b/src/main/java/dev/shadowsoffire/attributeslib/mixin/LivingEntityMixin.java
@@ -118,6 +118,7 @@ public abstract class LivingEntityMixin extends Entity {
         .add(ALObjects.Attributes.OVERHEAL)
         .add(ALObjects.Attributes.GHOST_HEALTH)
         .add(ALObjects.Attributes.MINING_SPEED)
+        .add(ALObjects.Attributes.ARROW_DAMAGE)
         .add(ALObjects.Attributes.ARROW_VELOCITY)
         .add(ALObjects.Attributes.HEALING_RECEIVED)
         .add(ALObjects.Attributes.ARMOR_PIERCE)

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,7 +36,8 @@
 	},
 	"custom": {
 		"cardinal-components": [
-			"zenith_attributes:arrow_done"
+			"zenith_attributes:arrow_velocity_done",
+			"zenith_attributes:arrow_damage_done"
 		]
 	},
 	"mixins": [

--- a/src/main/resources/zenith_attributes.mixins.json
+++ b/src/main/resources/zenith_attributes.mixins.json
@@ -4,6 +4,7 @@
   "plugin": "dev.shadowsoffire.attributeslib.mixin.compat.Plugin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "AbstractArrowMixin",
     "AttributeMixin",
     "CombatRulesMixin",
     "ItemStackMixin",


### PR DESCRIPTION
Instead of migrating to Ranged Weapon API, ZenithAttributes should simply create its own implementation for AttributesLib's `ARROW_DAMAGE` in a compatible way. 

`ARROW_DAMAGE` has slightly unexpected behavior/range, being indexed at 1.0 and functioning as a multiplier for arrow damage, unlike Projectile Damage/RangedWeapon API whose damage attributes are the total base value. 

This discrepancy is the partial cause for https://github.com/muon-rw/Zephyr/issues/6 and https://github.com/TheWinABagel/Zenith/issues/169 due to [the values of this affix](https://github.com/TheWinABagel/Zenith/blob/1.20/src/main/resources/data/zenith/affixes/ranged/attribute/elven.json)

Implementation:
- Arrow Damage modification is triggered with `@ModifyVariable` on setDamage in AbstractArrowMixin, passing in any original value
- New component `ARROW_DAMAGE_DONE` is added to ensure damage modification is only applied once (I'm not actually sure this is necessary, or even how necessary the original ARROW_DONE is)
- `ARROW_DONE` component renamed to `ARROW_VELOCITY_DONE` - old values should be ignored by CCA without issue
- Removed Projectile Damage from project

Tested on skeletons and player, seems to work well 